### PR TITLE
Suggested changes to About and cleanup styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -38,18 +38,31 @@
   <section class="about">
     <div class="container">
       <h3 class="centered">Over the years EBARC has accumulated many found memories and useful information.  Here are some of our <a href="events-past.html">Past Events</a>, <a href="photos.html">Photos</a>, <a href="news.html">Newsletters</a> and <a href="links.html">Links</a></h3>
-      <div class="section-thumb-container"><div class="section-thumb">History</div></div>
-      <p>EBARC maintained a club station in Richmond for many years, complete with several HF transceivers, tower-mounted yagi antennas, VHF/UHF stations for local emergency communication, our own off-the-grid power source, and a packet station. Unfortuntately, the City of Richmond has reallocated this site to another use and we are currently looking for a suitable site in which to relocate.</p>
     </div>
+  </section>
+
+  <section class="about-history">
+    <div class="section-thumb-container"><div class="section-thumb">History</div></div>
+    <p>EBARC maintained a club station in Richmond for many years, complete with several HF transceivers, tower-mounted yagi antennas, VHF/UHF stations for local emergency communication, our own off-the-grid power source, and a packet station. Unfortuntately, the City of Richmond has reallocated this site to another use and we are currently looking for a suitable site in which to relocate.</p>
+  </section>
+
+  <section class="about-affiliation">
     <div class="section-thumb-container"><div class="section-thumb">Affiliation</div></div>
     <p>EBARC is proud to be affiliated with the American Amateur Radio League - ARRL</p>
-  </div>
-</section>
-<section   <div class="page-about-arrl"></div>
-</section>
+    <div class="about-arrl">
+      <img src="./img/Hello_Logo-high-fixed.jpg" alt="ARRL banner: Hello Celebrating 100 Years of Voice over Radio Wordwide">
+    </div>
+  </section>
+  
+  <section class="about-bod">
+      <div class="section-thumb-container"><div class="section-thumb">Board of Directors</div></div>
+    <div class="gsheet-embed">
+      <iframe class="barc-bod" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSNI_eT3nxBV4A2X6c81Vc-Y1PGw6so0vD4PowKv2l_6RDXEQv4kOrdDcy2R8dVUj9pnpGV84bMuu3y/pubhtml?gid=2134483221&amp;single=true&amp;widget=true&amp;headers=false" width="640" height="310"></iframe>
+    </div>
+  </section>
 
-<footer>
-      <p>EBARC, PO Box 1393, El Cerrito, CA 94530</p>
+  <footer>
+    <p>EBARC, PO Box 1393, El Cerrito, CA 94530</p>
   </footer>
 </body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -95,13 +95,6 @@ header.main-header {
   background-size: cover;
   background-image: url(../img/page-about-image-ft-8.png);
 }
-
-.page-about-arrl{
-  background-position: center;
-  background-image: url(../img/Hello_Logo-high-fixed.jpg);
-  background-repeat: no-repeat;
-
-}
 .page-have {background-position: center;
 /*  background-size: cover;  */
   background-size: 30%;


### PR DESCRIPTION
You named a selector `.page-about-arrl`, which intimated that it was a page banner, it's not. I deleted it because a better way to place images that don't need text on them is to just use the `<img>` tag. In this case, because it's an image of text, I added the text to the `alt` attribute, to make it accessible to screen readers.

I embedded the BoD Google Sheet named range, _Board of Directors_ using Google Sheets' **File | Publish to Web...**  menu

I rewrote `about.html` to make semantic sections. More can probably be done to make it more semantic. 