### PR TITLE
Make Twitter button mention-type

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -68,7 +68,7 @@
   </section>
   
   <section>
-    <a href="https://twitter.com/intent/tweet?button_hashtag=w6cus&ref_src=twsrc%5Etfw" class="twitter-hashtag-button" data-size="large" data-show-count="false">Tweet #w6cus</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <a href="https://twitter.com/intent/tweet?screen_name=w6cus&ref_src=twsrc%5Etfw" class="twitter-mention-button" data-size="large" data-show-count="true"></a>
   </section>
   
   <!--
@@ -96,5 +96,6 @@
   <footer>
     <p>EBARC, PO Box 1393, El Cerrito, CA 94530</p>
   </footer>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </body>
 </html>


### PR DESCRIPTION
Changed the markup so it's not a hashtag-type button. The aim is for people to easily mention you in their tweets, including your handle (i.e., screen name) at Twitter, which is also a link to your Twitter profile.