### PR TITLE
Make thumbnails variable height to account for portrait oriented images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -374,7 +374,7 @@ section {
   .photo-gallery .thumbnail .wrapper:hover {
     border: 1px solid #5d8888; }
   .photo-gallery .thumbnail .photo {
-    max-height: 150px;
+    /* max-height: 150px; */
     overflow: hidden;
     width: 100%; }
   .photo-gallery .thumbnail .desc {


### PR DESCRIPTION
Since I don't understand what was meant by the the language used in Issue #37, this PR makes thumbnails display the full height of an image to account for portrait oriented photos.